### PR TITLE
Usbddx-16

### DIFF
--- a/usbddc/pom.xml
+++ b/usbddc/pom.xml
@@ -10,8 +10,15 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>usbddc</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.7.0</version>
+        </dependency>
+    </dependencies>
 
-<!--    <properties>-->
+    <!--    <properties>-->
 <!--        <maven.compiler.source>11</maven.compiler.source>-->
 <!--        <maven.compiler.target>11</maven.compiler.target>-->
 <!--    </properties>-->

--- a/usbddc/src/main/java/ru/pel/usbddc/entity/USBDevice.java
+++ b/usbddc/src/main/java/ru/pel/usbddc/entity/USBDevice.java
@@ -4,11 +4,13 @@ import lombok.Getter;
 import lombok.Setter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ru.pel.usbddc.utility.IgnoreNullBeanUtilsBean;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
 /**
@@ -49,7 +51,7 @@ public class USBDevice {
     private String volumeName;
     private String revision;
     private boolean isSerialOSGenerated;
-    private List<String> userAccountsList;
+//    private List<String> userAccountsList;
 //    private final String service; //TODO узнать назначение одноименного параметра в реестре винды
     private List<UserProfile> userAccountsList;
 
@@ -85,22 +87,13 @@ public class USBDevice {
     }
 
     /**
-     * Выполняет копирование значений полей из src в объект. Копируются не null'евые значения.
+     * Выполняет копирование свойств из src в текущий объект. Свойства равные null в источнике игнорируются - в
+     * текущем объекте свойство остается неизменным.
      *
      * @param src Устройство, свойства которого необходимо скопировать.
      */
-    public void fillFieldsFrom(USBDevice src) {
-        this.friendlyName = src.getFriendlyName();
-        this.guid = src.getGuid();
-        this.pid = src.getPid();
-        this.productName = src.getProductName();
-        this.serial = src.getSerial();
-        this.vendorName = src.getVendorName();
-        this.vid = src.getVid();
-        this.volumeName = src.getVolumeName();
-        this.revision = src.getRevision();
-        this.isSerialOSGenerated = src.isSerialOSGenerated();
-        this.userAccountsList = new ArrayList<>(src.getUserAccountsList());
+    public void copyNonNullProperties(USBDevice src) throws InvocationTargetException, IllegalAccessException {
+        new IgnoreNullBeanUtilsBean().copyProperties(this,src);
     }
 
     @Override
@@ -235,7 +228,7 @@ public class USBDevice {
          *
          * @param vid Vendor ID
          * @param pid Product ID
-         * @return
+         * @return возвращает билдер.
          */
         public Builder withVidPid(String vid, String pid) {
             newUsbDevice.vid = vid;

--- a/usbddc/src/main/java/ru/pel/usbddc/entity/USBDevice.java
+++ b/usbddc/src/main/java/ru/pel/usbddc/entity/USBDevice.java
@@ -77,13 +77,12 @@ public class USBDevice {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         USBDevice usbDevice = (USBDevice) o;
-        return isSerialOSGenerated == usbDevice.isSerialOSGenerated &&
-                Objects.equals(pid, usbDevice.pid) &&
-                Objects.equals(productName, usbDevice.productName) &&
-                Objects.equals(serial, usbDevice.serial) &&
-                Objects.equals(vendorName, usbDevice.vendorName) &&
-                Objects.equals(vid, usbDevice.vid) &&
-                Objects.equals(revision, usbDevice.revision);
+        return isSerialOSGenerated == usbDevice.isSerialOSGenerated && Objects.equals(friendlyName, usbDevice.friendlyName) && Objects.equals(guid, usbDevice.guid) && Objects.equals(pid, usbDevice.pid) && Objects.equals(productName, usbDevice.productName) && Objects.equals(serial, usbDevice.serial) && Objects.equals(vendorName, usbDevice.vendorName) && Objects.equals(vid, usbDevice.vid) && Objects.equals(volumeName, usbDevice.volumeName) && Objects.equals(revision, usbDevice.revision) && Objects.equals(userAccountsList, usbDevice.userAccountsList);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(friendlyName, guid, pid, productName, serial, vendorName, vid, volumeName, revision, isSerialOSGenerated, userAccountsList);
     }
 
     /**
@@ -94,11 +93,6 @@ public class USBDevice {
      */
     public void copyNonNullProperties(USBDevice src) throws InvocationTargetException, IllegalAccessException {
         new IgnoreNullBeanUtilsBean().copyProperties(this,src);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(pid, productName, serial, vendorName, vid, revision, isSerialOSGenerated);
     }
 
     /**

--- a/usbddc/src/main/java/ru/pel/usbddc/entity/USBDevice.java
+++ b/usbddc/src/main/java/ru/pel/usbddc/entity/USBDevice.java
@@ -1,6 +1,5 @@
 package ru.pel.usbddc.entity;
 
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.slf4j.Logger;
@@ -29,12 +28,17 @@ import java.util.*;
 
 @Getter
 @Setter
-@EqualsAndHashCode
+//@EqualsAndHashCode
 public class USBDevice {
     private static final Logger logger = LoggerFactory.getLogger(USBDevice.class.getName());
     @Getter
     @Setter
     private static String usbIds;
+
+    static {
+        usbIds = "usb.ids";
+    }
+
     private String friendlyName;
     private String guid;
     private String pid;
@@ -47,10 +51,7 @@ public class USBDevice {
     private boolean isSerialOSGenerated;
     private List<String> userAccountsList;
 //    private final String service; //TODO узнать назначение одноименного параметра в реестре винды
-
-    static {
-        usbIds = "usb.ids";
-    }
+    private List<UserProfile> userAccountsList;
 
     private USBDevice() {
         friendlyName = "";
@@ -81,6 +82,25 @@ public class USBDevice {
                 Objects.equals(vendorName, usbDevice.vendorName) &&
                 Objects.equals(vid, usbDevice.vid) &&
                 Objects.equals(revision, usbDevice.revision);
+    }
+
+    /**
+     * Выполняет копирование значений полей из src в объект. Копируются не null'евые значения.
+     *
+     * @param src Устройство, свойства которого необходимо скопировать.
+     */
+    public void fillFieldsFrom(USBDevice src) {
+        this.friendlyName = src.getFriendlyName();
+        this.guid = src.getGuid();
+        this.pid = src.getPid();
+        this.productName = src.getProductName();
+        this.serial = src.getSerial();
+        this.vendorName = src.getVendorName();
+        this.vid = src.getVid();
+        this.volumeName = src.getVolumeName();
+        this.revision = src.getRevision();
+        this.isSerialOSGenerated = src.isSerialOSGenerated();
+        this.userAccountsList = new ArrayList<>(src.getUserAccountsList());
     }
 
     @Override
@@ -202,6 +222,11 @@ public class USBDevice {
             } else {
                 newUsbDevice.isSerialOSGenerated = serial.charAt(1) == '&';
             }
+            return this;
+        }
+
+        public Builder withUserProfileList(List<UserProfile> userProfileList) {
+            newUsbDevice.userAccountsList = new ArrayList<>(userProfileList);
             return this;
         }
 

--- a/usbddc/src/main/java/ru/pel/usbddc/utility/IgnoreNullBeanUtilsBean.java
+++ b/usbddc/src/main/java/ru/pel/usbddc/utility/IgnoreNullBeanUtilsBean.java
@@ -1,0 +1,14 @@
+package ru.pel.usbddc.utility;
+
+import org.apache.commons.beanutils.BeanUtilsBean;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class IgnoreNullBeanUtilsBean extends BeanUtilsBean {
+    @Override
+    public void copyProperty(Object dest, String name, Object value)
+            throws IllegalAccessException, InvocationTargetException {
+        if (value == null) return;
+        super.copyProperty(dest, name, value);
+    }
+}

--- a/usbddc/src/test/java/ru/pel/usbddc/entity/USBDeviceTest.java
+++ b/usbddc/src/test/java/ru/pel/usbddc/entity/USBDeviceTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.InvocationTargetException;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class USBDeviceTest {
@@ -30,6 +32,35 @@ class USBDeviceTest {
     }
 
     @Test
+    @DisplayName("Копирование не нулевых полей")
+    void copyNonNullProperties() {
+        USBDevice dst = USBDevice.getBuilder()
+                .withSerial("12345")
+                .withGuid(null)
+                .withVolumeName("oldVolumeName").build();
+        USBDevice src = USBDevice.getBuilder()
+                .withSerial("testSerial")
+                .withGuid("{1}")
+                .withVolumeName(null)
+                .build();
+
+        try {
+            dst.copyNonNullProperties(src);
+
+            assertAll(                                                              //проверяем качество заполнения полей:
+                    () -> assertEquals(dst.getSerial(), src.getSerial()),              //явный null и
+                    () -> assertEquals("{1}", dst.getGuid()),                  //неявный null переписывается значением,
+                    () -> assertEquals("oldVolumeName", dst.getVolumeName()),  //но значение НЕ переписывается null'ем.
+                    () -> dst.setGuid("{2}"),                                         //Изменение одного из объектов
+                    () -> assertEquals("{2}", dst.getGuid()),                  //не влияет
+                    () -> assertNotEquals("{2}", src.getGuid())             //на состояние другого.
+            );
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
     void isSerialOSGenerated() {
         USBDevice OSGeneratedSerial1 = USBDevice.getBuilder().withSerial("0&123456789").build();
         USBDevice OSGeneratedSerial2 = USBDevice.getBuilder().withSerial("0&123456789&0").build();
@@ -37,10 +68,10 @@ class USBDeviceTest {
         USBDevice vendorGeneratedSerial2 = USBDevice.getBuilder().withSerial("0123456789&0").build();
 
         assertAll(
-                ()->assertTrue(OSGeneratedSerial1.isSerialOSGenerated(),"Символ '&' ДОЛЖЕН стоять во второй позиции"),
-                ()->assertTrue(OSGeneratedSerial2.isSerialOSGenerated(),"Символ '&' ДОЛЖЕН стоять во второй позиции"),
-                ()->assertFalse(vendorGeneratedSerial1.isSerialOSGenerated(),"Символ '&' НЕ должен стоять во второй позиции"),
-                ()->assertFalse(vendorGeneratedSerial2.isSerialOSGenerated(),"Символ '&' НЕ должен стоять во второй позиции")
+                () -> assertTrue(OSGeneratedSerial1.isSerialOSGenerated(), "Символ '&' ДОЛЖЕН стоять во второй позиции"),
+                () -> assertTrue(OSGeneratedSerial2.isSerialOSGenerated(), "Символ '&' ДОЛЖЕН стоять во второй позиции"),
+                () -> assertFalse(vendorGeneratedSerial1.isSerialOSGenerated(), "Символ '&' НЕ должен стоять во второй позиции"),
+                () -> assertFalse(vendorGeneratedSerial2.isSerialOSGenerated(), "Символ '&' НЕ должен стоять во второй позиции")
         );
     }
 
@@ -49,16 +80,16 @@ class USBDeviceTest {
         USBDevice sameUsbDevice = testUsbDevice;
         USBDevice copyOfTestUsbDevice = USBDevice.getBuilder()
                 .withSerial(SERIAL)
-                .withVidPid(VID,PID).build();
+                .withVidPid(VID, PID).build();
         USBDevice otherUsbDevice = USBDevice.getBuilder()
                 .withSerial("other" + SERIAL)
-                .withVidPid(VID,PID).build();
+                .withVidPid(VID, PID).build();
 
         assertAll(
                 () -> assertEquals(testUsbDevice, sameUsbDevice, "Переменные должны ссылаться на один объект"),
-                ()-> assertEquals(testUsbDevice, copyOfTestUsbDevice, "Переменные должны указывать на разные, но идентичные объекты"),
+                () -> assertEquals(testUsbDevice, copyOfTestUsbDevice, "Переменные должны указывать на разные, но идентичные объекты"),
                 () -> assertNotEquals(testUsbDevice, otherUsbDevice, "Переменные должны указывать на разные и не идентичные объекты"),
-                ()-> assertNotEquals("", testUsbDevice, "Должна происходить попытка сравнения объектов разного типа")
+                () -> assertNotEquals("", testUsbDevice, "Должна происходить попытка сравнения объектов разного типа")
         );
     }
 }


### PR DESCRIPTION
Реализован метод copyNonNullProperties(USBDevice) в классе USBDevice. Выполняет копирование ненулевых значений свойств объекта источника.

Метод основан на классе IgnoreNullBeanUtilsBean (наследник BeanUtilsBean) с переопределенным методом copyProperty.