### PR TITLE
Не корректно заполнялся столбец даты первой установки устройства

### DIFF
--- a/usbddc/src/main/java/ru/pel/usbddc/config/UsbddcConfig.java
+++ b/usbddc/src/main/java/ru/pel/usbddc/config/UsbddcConfig.java
@@ -21,14 +21,23 @@ import java.util.Properties;
 public class UsbddcConfig {
     private static final Logger logger = LoggerFactory.getLogger(UsbddcConfig.class);
     //TODO а нужен ли тут вообще синглтон, может все поля перегнать в статик и класс сделать utility?
-    private static volatile UsbddcConfig instance;
-    private int threadPoolSize;
-    private String usbIdsPath;
-
-    {
-        threadPoolSize = 8;
-        usbIdsPath = "usb.ids";
-    }
+    private static UsbddcConfig instance;
+    /**
+     * <p>Максимальный размер пула поток. В настоящее время используется в анализаторах. </p>
+     * <p>Значение по умолчанию - 8.</p>
+     */
+    private int threadPoolSize = 8;
+    /**
+     * <p>Путь к файлу <a href=http://www.linux-usb.org/usb.ids>usb.ids</a>, содержащему расшифровку VID/PID.</p>
+     * <p>Значение по умолчанию - usb.ids.</p>
+     */
+    private String usbIdsPath = "usb.ids";
+    /**
+     * <p>Признак фильтрации серийных номеров устройств. True - отбрасывать номера, содержащие в своем составе нечитаемые символы.
+     * False - выводить все найденные серийные номера.</p>
+     * <p>Значение по умолчанию - false.</p>
+     */
+    private boolean isSkipSerialTrash = false;
 
     private UsbddcConfig(String pathToConfig) {
 
@@ -38,6 +47,7 @@ public class UsbddcConfig {
             config.loadFromXML(file);
             threadPoolSize = Integer.parseInt(config.getProperty("threadPoolSize"));
             usbIdsPath = config.getProperty("usbIdsPath");
+            isSkipSerialTrash = Boolean.parseBoolean(config.getProperty("isSkipSerialTrash"));
 
         } catch (IOException e) {
             logger.warn("Используется конфигурация по умолчанию, т.к. не удалось загрузить конфигурацию из файла {}. Причина: {}",

--- a/usbddc/src/main/java/ru/pel/usbddc/entity/UserProfile.java
+++ b/usbddc/src/main/java/ru/pel/usbddc/entity/UserProfile.java
@@ -29,6 +29,11 @@ public class UserProfile {
         return Objects.hash(username, profileImagePath, securityId);
     }
 
+    @Override
+    public String toString() {
+        return username;
+    }
+
     public static Builder getBuilder() {
         return new Builder();
     }

--- a/usbddc/src/main/java/ru/pel/usbddc/service/IgnoreNullBeanUtilsBean.java
+++ b/usbddc/src/main/java/ru/pel/usbddc/service/IgnoreNullBeanUtilsBean.java
@@ -3,12 +3,19 @@ package ru.pel.usbddc.service;
 import org.apache.commons.beanutils.BeanUtilsBean;
 
 import java.lang.reflect.InvocationTargetException;
+import java.time.LocalDateTime;
 
 public class IgnoreNullBeanUtilsBean extends BeanUtilsBean {
     @Override
     public void copyProperty(Object dest, String name, Object value)
             throws IllegalAccessException, InvocationTargetException {
         if (value == null || value.equals("")) return;
+        if (value instanceof LocalDateTime){
+            LocalDateTime dateTime = (LocalDateTime) value;
+            if (dateTime.isEqual(LocalDateTime.MIN)){
+                return;
+            }
+        }
         super.copyProperty(dest, name, value);
     }
 }

--- a/usbddc/src/main/java/ru/pel/usbddc/service/SetupapiDevLogAnalyzer.java
+++ b/usbddc/src/main/java/ru/pel/usbddc/service/SetupapiDevLogAnalyzer.java
@@ -3,6 +3,8 @@ package ru.pel.usbddc.service;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import ru.pel.usbddc.entity.USBDevice;
 
 import java.io.BufferedReader;
@@ -19,6 +21,7 @@ import java.util.regex.Pattern;
 @Getter
 @Setter
 public class SetupapiDevLogAnalyzer implements Analyzer{
+    private static final Logger logger = LoggerFactory.getLogger(SetupapiDevLogAnalyzer.class);
     private static final String NOT_PARSED = "<SERIAL IS NOT PARSED IN LOG>";
     @Setter
     private static Path pathToLog;
@@ -122,8 +125,9 @@ public class SetupapiDevLogAnalyzer implements Analyzer{
      *                                  default provider, the checkRead method is invoked to check read access to the directory.
      */
     public Map<String, USBDevice> parseAllSetupapiDevLogs() throws IOException {
-        List<Path> devLogList = new OSInfoCollector().getSetupapiDevLogList();
-        for (Path devLog : devLogList) {
+//        List<Path> devLogList = new OSInfoCollector().getSetupapiDevLogList();
+//        for (Path devLog : devLogList) {
+        for (Path devLog : setupapiDevLogList) {
             try (BufferedReader reader = new BufferedReader(new FileReader(devLog.toString()))) {
                 String currStr = reader.readLine();
                 while (currStr != null) {
@@ -154,6 +158,9 @@ public class SetupapiDevLogAnalyzer implements Analyzer{
                     }
                     currStr = reader.readLine();
                 }
+            }catch (IOException e){
+                logger.error("Ошибка парсинга лога {}", e.getLocalizedMessage());
+                throw e;
             }
         }
         return usbDeviceMap;

--- a/usbddc/src/main/resources/config.xml
+++ b/usbddc/src/main/resources/config.xml
@@ -4,4 +4,5 @@
     <comment>xml example</comment>
     <entry key="threadPoolSize">8</entry>
     <entry key="usbIdsPath">usb.ids</entry>
+    <entry key="isSkipSerialTrash">false</entry>
 </properties>

--- a/usbddc/src/main/resources/logback.xml
+++ b/usbddc/src/main/resources/logback.xml
@@ -9,9 +9,9 @@
     </appender>
 
     <logger name="org.apache.commons.beanutils.BeanUtils" level="warn"/>
-    <logger name="ru.pel.usbddc.gui.MainFrame" level="trace"/>
-    <logger name="ru.pel.usbddc.service.SystemInfoCollector" level="trace"/>
-    <logger name="ru.pel.usbddc.service.OSInfoCollector" level="trace"/>
+    <logger name="ru.pel.usbddc.gui.MainFrame" level="debug"/>
+    <logger name="ru.pel.usbddc.service.SystemInfoCollector" level="debug"/>
+    <logger name="ru.pel.usbddc.service.OSInfoCollector" level="debug"/>
 
     <root level="debug">
         <appender-ref ref="STDOUT"/>

--- a/usbddc/src/test/java/ru/pel/usbddc/service/SetupapiDevLogAnalyzerTest.java
+++ b/usbddc/src/test/java/ru/pel/usbddc/service/SetupapiDevLogAnalyzerTest.java
@@ -45,7 +45,17 @@ class SetupapiDevLogAnalyzerTest {
         Map<String, USBDevice> usbDeviceMap = new SetupapiDevLogAnalyzer().parseAllSetupapiDevLogs();
 
         assertAll(
-                () -> assertEquals(expectedDateTimeInstall, usbDeviceMap.get(SERIAL).getDateTimeFirstInstall())
+                () -> assertEquals(expectedDateTimeInstall, usbDeviceMap.get(SERIAL).getDateTimeFirstInstall()),
+                () -> assertEquals(LocalDateTime.of(2020,4,13, 14,49,24),
+                        usbDeviceMap.get("00000000000E07").getDateTimeFirstInstall())
         );
+    }
+
+    @Test
+    void parseDateTimeFirstInstallOfSerial() throws IOException {
+        Map<String, USBDevice> usbDeviceMap = new SetupapiDevLogAnalyzer().parseAllSetupapiDevLogs();
+
+        assertEquals(LocalDateTime.of(2016,11,28,11,3,24),
+                usbDeviceMap.get("00000").getDateTimeFirstInstall());
     }
 }

--- a/usbddc/src/test/java/ru/pel/usbddc/service/SetupapiDevLogAnalyzerTest.java
+++ b/usbddc/src/test/java/ru/pel/usbddc/service/SetupapiDevLogAnalyzerTest.java
@@ -58,4 +58,7 @@ class SetupapiDevLogAnalyzerTest {
         assertEquals(LocalDateTime.of(2016,11,28,11,3,24),
                 usbDeviceMap.get("00000").getDateTimeFirstInstall());
     }
+    //строка в которой не распознается серийный номер 00000
+    //>>>  [Device Install (Hardware initiated) - SWD\WPDBUSENUM\_??_USBSTOR#Disk&Ven_Generic-&Prod_xD#SD#M.S.&Rev_1.00#00000#{53f56307-b6bf-11d0-94f2-00a0c91efb8b}]
+    //>>>  Section start 2016/11/28 11:03:24.136
 }


### PR DESCRIPTION
Основной исправленный баг - не правильно заполнялся столбец первой установки устройства (дата и время берутся из dev.log'а) - причина метод копирования ненулевых значений в USBDevice. Метод исправлен, вероятно, не самая оптимальная реализация.